### PR TITLE
💄 auth dapper wallet, ledger wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
-
+.env
 # vercel
 .vercel
 

--- a/flow/config.js
+++ b/flow/config.js
@@ -4,5 +4,6 @@ config({
   "accessNode.api": "https://rest-testnet.onflow.org", // Mainnet: "https://rest-mainnet.onflow.org"
   "discovery.wallet": "https://fcl-discovery.onflow.org/testnet/authn", // Mainnet: "https://fcl-discovery.onflow.org/authn"
   "app.detail.title": "Zingiber Hackathon App",
+  "discovery.authn.include": ["0x9d2e44203cb13051", "0x82ec283f88a62e65"],
   "app.detail.icon": "https://i.imgur.com/9I6NRUm.png",
 });


### PR DESCRIPTION
By default, limited functionality services or services that require developer registration, like Ledger or Dapper Wallet, require apps to opt-in in order to display to users. To enable opt-in services in an application, use the discovery.authn.include property in your configuration with a value of an array of services you'd like your app to opt-in to displaying for users.

https://developers.flow.com/tools/fcl-js/reference/api#discovery